### PR TITLE
File Errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.3.0 - 2019-10-19
+
+### Changed
+
+- Strip all newlines from the error message output.
+
+### Fixed
+
+- Fix a bug where files that occur on an entire file/module would break the linter.
+
 ## v0.2.1 - 2019-09-23
 
 ### Fixed

--- a/messages.json
+++ b/messages.json
@@ -1,3 +1,4 @@
 {
-    "install": "messages/install.txt"
+    "install": "messages/install.txt",
+    "0.3.0": "messages/0.3.0.txt"
 }

--- a/messages/0.3.0.txt
+++ b/messages/0.3.0.txt
@@ -1,0 +1,10 @@
+SublimeLinter-terraform v0.3.0
+==============================
+
+### Changed
+
+- Strip all newlines from the error message output.
+
+### Fixed
+
+- Fix a bug where files that occur on an entire file/module would break the linter.


### PR DESCRIPTION
This PR fixes a bug where the plugin would crash for files that occurred on an entire file/module — i.e. they did not have a `range` key.